### PR TITLE
Use lower case logrus import

### DIFF
--- a/logrus_sqs.go
+++ b/logrus_sqs.go
@@ -1,12 +1,13 @@
 package logrus_sqs
 
 import (
-	"fmt"
 	"encoding/json"
-	"github.com/Sirupsen/logrus"
+	"fmt"
+
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/sqs"
+	"github.com/sirupsen/logrus"
 )
 
 type SQSHook struct {

--- a/logrus_sqs_test.go
+++ b/logrus_sqs_test.go
@@ -2,7 +2,8 @@ package logrus_sqs
 
 import (
 	"testing"
-	log "github.com/Sirupsen/logrus"
+
+	log "github.com/sirupsen/logrus"
 )
 
 func TestSQSHook_Fire(t *testing.T) {


### PR DESCRIPTION
The package will currently collide with other packages that use a (now standard) lower case import of package logrus.